### PR TITLE
Fixes for building yosys on M1 and M2 Macs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ std::vector<RTLIL::Design*> pushed_designs;
 YOSYS_NAMESPACE_END
 END
 
-sed -e 's,new ezMiniSAT(),nullptr,' -i yosys-src/kernel/register.cc
+sed -e 's,new ezMiniSAT(),nullptr,' -i.bak yosys-src/kernel/register.cc
 
 YOSYS_PYPI_VER=$(python3 setup.py --version)
 YOSYS_GIT_REV=$(git -C yosys-src rev-parse --short HEAD | tr -d '\n')

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,14 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
+
+OS=`uname -s`
+if [ $OS = "Darwin" ] ; then
+  WASI_OS="macos"
+else
+  WASI_OS="linux"
+fi
 
 WASI_SDK=wasi-sdk-11.0
-WASI_SDK_URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-11/wasi-sdk-11.0-linux.tar.gz
+WASI_SDK_URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-11/wasi-sdk-11.0-$WASI_OS.tar.gz
 if ! [ -d ${WASI_SDK} ]; then curl -L ${WASI_SDK_URL} | tar xzf -; fi
 
 # This script does a lot of really awful things to Yosys to make the WASM artifact smaller.

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,13 @@
 OS=`uname -s`
 if [ $OS = "Darwin" ] ; then
   WASI_OS="macos"
+  if command -v brew ; then
+    brew install make
+    brew install pkg-config
+    brew install gnu-sed
+    brew install ccache
+    brew install bison
+  fi
 else
   WASI_OS="linux"
 fi

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     python_requires="~=3.5",
     install_requires=[
         "importlib_resources>=1.4; python_version<'3.9'",
-        "wasmtime>=0.30,<0.33"
+        "wasmtime>=0.30"
     ],
     packages=["amaranth_yosys"],
     package_data={"amaranth_yosys": ["yosys.wasm", "share/**/**/**/*"]},


### PR DESCRIPTION
Fixes #6.
This assumes using brew to build (needed for yosys build anyhow, so fair assumption).
It checks the architecture, installs any needed dependencies with brew, picks up the right WASI SDK, and removes the upper bound on wasmtime version. 

It may make sense to shift to wasmtime 1.0.x now it is out, or put in an upper version of 0.40.1, the minimum needed for M1/M2 compatibility.
