### PR TITLE
Robtaylor/ci actions node16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,14 +46,14 @@ jobs:
         path: dist/
     - name: Publish wheels to Test PyPI
       if: github.event_name == 'push' && github.event.ref == 'refs/heads/develop'
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.test_pypi_token }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish wheels to PyPI
       if: github.event_name == 'push' && github.event.ref == 'refs/heads/release'
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,18 +6,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
       - name: Install dependencies
         run: |
           python -m pip install setuptools_scm # for setup.py --version
           sudo apt-get install flex bison ccache
       - name: Set up ccache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-
@@ -28,7 +28,7 @@ jobs:
         run: |
           pip wheel -e . -w dist/
       - name: Upload binary wheel artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheel
           path: dist/amaranth_yosys-*.whl
@@ -40,7 +40,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: wheel
         path: dist/


### PR DESCRIPTION
Fixes #8 by bumping github actions to v3.
Should fix #9 by using the release/v1 ref for gh-action-pypi-publish, but I'm unable to test this myself.